### PR TITLE
#13 - Modified to hook module ::ActionController::Flash rather than ::ActionController::Redirect

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -1,20 +1,20 @@
 module Paloma
 
   # TODO explain!
-  module ::ActionController::Redirecting
+  module ::ActionController::Flash
     alias_method :original_redirect_to, :redirect_to
   end
 
-  
+
 
   module ActionControllerExtension
-    def redirect_js_hook options = {}, response_status = {}
+    def redirect_js_hook options = {}, response_status_and_flash = {}
       add_to_callbacks @__paloma_callback__
-      original_redirect_to options, response_status
-    end      
+      original_redirect_to options, response_status_and_flash
+    end
     alias_method :redirect_to, :redirect_js_hook
-    
-    
+
+
     #
     # js false
     # js :new, :params => {}
@@ -24,31 +24,31 @@ module Paloma
     def js options = {}, extras = {}
       callback = {:controller => controller_path, :action => action_name}
       params = {}
-      
+
       if options.is_a? Hash
         params = options[:params]
-        callback = options[:controller].present? && options[:action].present? ? 
+        callback = options[:controller].present? && options[:action].present? ?
           {:controller => options[:controller], :action => options[:action]} :
           callback
 
       elsif options.is_a? Symbol
-        params = extras[:params] 
+        params = extras[:params]
         callback[:action] = options
-      
+
       elsif options.is_a? FalseClass
         callback = nil
       end
-      
+
       params ||= {}
-      
+
       # Include request details
       params[:controller_path] = controller_path
       params[:action] = action_name
-      
+
       @__paloma_callback__ = callback.present? ? callback.merge({:params => params}) : nil
-    end 
+    end
   end
-  
+
 
   ::ActionController::Base.send :include, ActionControllerExtension
 end


### PR DESCRIPTION
re: issue #13 
Modified to hook module ::ActionController::Flash rather than ::ActionController::Redirect so that flash messages still work when using e.g.

redirect_to some_url, notice: 'some notice'
