### PR TITLE
Add some keywords in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,18 +162,18 @@ For instance, if the current response is from the `new` action of the `Users` co
 
 You can manipulate callback behavior by using the `js` command before the `render` or `redirect_to` command in your controllers.
 
-1. Preventing the Callback to execute.
+1. Preventing the Callback to execute by avoiding Paloma to add js code in the view.
 
     ```ruby
     def destroy
         user = User.find params[:id]
         user.destroy
         
-        js false
+        js false # No paloma js code in the view
     end
     ```
     
-    `callbacks["controller"]["destroy"]` will not be executed.
+    `callbacks["controller"]["destroy"]` will not be added in the view, therefore not executed. This is useful for AJAX response, or any non HTML response.
 
 2. Using other action's callback from the same controller.
 


### PR DESCRIPTION
I spent a few hours to understand how to prevent Paloma from adding callback code after the view, and my Google searches were unsuccessful with keywords like "rails paloma no js in view", or "rails paloma ajax response".

I eventually found how to do it thanks to the changelog and a grep command on the gem code, but I think adding these keywords in the README would help other users to find about not displaying the callback in the view. 

Thank you for your work anyway, this gem is great.
