### PR TITLE
Updated action_controller.extension.rb to support Remotipart

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -80,9 +80,8 @@ module Paloma
     # Determine if an html view is being rendered
     #
     def html_is_rendered?
-      remotipart_request = respond_to?('remotipart_submitted?') && remotipart_submitted?
       not_redirect = self.status != 302
-      [nil, 'text/html'].include?(response.content_type) && not_redirect && !remotipart_request
+      [nil, 'text/html'].include?(request.format) && not_redirect
     end
 
 


### PR DESCRIPTION
Remotipart sends UJS responses in a wrapped html view.  Paloma sees this as a regular HTML view and will append the hook onto the request.  This will cause errors when the response is parsed on the client.
