### PR TITLE
Bug #37

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -115,10 +115,15 @@ module Paloma
       #
       def append_paloma_hook
         return true if self.paloma.has_no_request?
-
-        hook = view_context.render(
-                  :partial => 'paloma/hook',
-                  :locals => {:request => self.paloma.request})
+       
+        # Render the partial if it is present, otherwise do nothing. 
+        begin
+          hook = view_context.render(
+                   :partial => 'paloma/hook',
+                   :locals => {:request => self.paloma.request})
+        rescue ActionView::MissingTemplate
+          return true
+        end
 
         before_body_end_index = response_body[0].rindex('</body>')
 


### PR DESCRIPTION
Hi, I ran into a problem when I tried to use paloma and jbuilder in one rails application. The rendering of json failed because there was no partial available for paloma. I've seen that json should be excluded automatically, but somehow this does not seem to apply for the jbuilder rendering process (options hash is empty). One solution that came to mind is to just skip the rendering if there is no template available, that's what I've implemented here.

By the way, this also solves the issue described in Issue #37.

Hope it helps!
