### PR TITLE
Moving document.ready to init.js, to be in html header

### DIFF
--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -4,8 +4,10 @@
   <script type="text/javascript">
     (function(){
       // Do not continue if Paloma not found.
-      if (window['Paloma'] === undefined && window['console'] !== undefined){
-        console.warn("Paloma not found. Require it in your application.js.");
+      if (window['Paloma'] === undefined) {
+        if (window['console'] !== undefined) {
+          console.warn("Paloma not found. Require it in your application.js.");
+        }
         return true;
       }
 
@@ -20,8 +22,6 @@
         request['resource'],
         request['action'],
         request['params']);
-
-      $(document).ready(function(){ Paloma.engine.start(); });
     })();
   </script>
 </div>

--- a/vendor/assets/javascripts/paloma/init.js
+++ b/vendor/assets/javascripts/paloma/init.js
@@ -15,3 +15,15 @@ else {
     console.log(msg);
   };
 }
+
+$(document).ready(function(){
+  // Do not continue if Paloma not found.
+  if (window['Paloma'] === undefined) {
+    if (window['console'] !== undefined) {
+      console.warn("Paloma not found. Require it in your application.js.");
+    }
+    return true;
+  }
+
+  Paloma.engine.start();
+});


### PR DESCRIPTION
This fixes #40 and I really that it's better to have document.ready calls only in the header.

Also, if window.paloma is undefined you won't return true, unless a window.console exists. I thinks that's a minor bug.
