### PR TITLE
Update _hook.html.erb to prevent JS errors

### DIFF
--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -2,18 +2,20 @@
 
 <div class="js-paloma-hook" data-id="<%= id %>">
   <script type="text/javascript">
-    (function(){
-      Paloma.env = '<%= Rails.env %>';
+      if (typeof Paloma !== 'undefined') {
+          (function(){
+              Paloma.env = '<%= Rails.env %>';
 
-      // Remove any callback details if any
-      $('.js-paloma-hook[data-id!=' + <%= id %> + ']').remove();
+              // Remove any callback details if any
+              $('.js-paloma-hook[data-id!=' + <%= id %> + ']').remove();
 
-      var request = <%= request.to_json.html_safe %>;
+              var request = <%= request.to_json.html_safe %>;
 
-      Paloma.engine.setRequest(
-        request['resource'],
-        request['action'],
-        request['params']);
-    })();
+              Paloma.engine.setRequest(
+                      request['resource'],
+                      request['action'],
+                      request['params']);
+          })();
+      }
   </script>
 </div>


### PR DESCRIPTION
When adding Paloma to a pre-existing codebase, users may encounter a problem where some pages (i.e. in Rails Engines) do not load the Paloma Javascript [i.e. no //= require paloma]  

The hook expects Paloma to be defined.  If Paloma is not defined there will be an error and JS execution stops.

This patch prevents the hook from causing the JS error.