### PR TITLE
Check for the existence of Paloma in the hook Javascript

### DIFF
--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -3,6 +3,11 @@
 <div class="js-paloma-hook" data-id="<%= id %>">
   <script type="text/javascript">
     (function(){
+      // Do not continue if Paloma not found.
+      if (window['Paloma'] === undefined) {
+        return true;
+      }
+
       Paloma.env = '<%= Rails.env %>';
 
       // Remove any callback details if any


### PR DESCRIPTION
The changes in #57 reopened an old bug #5 where you get a Javascript error in Rails engines like Rails Admin.

The hook gets included in views rendered by engines but not the init.js so Paloma is not defined. This causes a Javascript error on all engine pages.

My proposed fix is to silently ignore when Paloma is missing in the hook in order to avoid a warning on every page in an engine.

By the way #57 moved the warning "Paloma not found. Require it in your application.js" into a file that gets included in application.js. So if you don't include paloma.js in you application, you won't see the message. If you do include it, the Paloma will be defined. So you would never actually see the warning, right?