### PR TITLE
Force gem user to explicitly insert hook in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ def UsersController < ApplicationController
 end
 ```
 
+In layout `app/views/layout/application.html.erb`
+
+```erb
+<html>
+  <body>
+	<!-- etc -->
+    <%= insert_paloma_hook %>
+  </body>
+</html>
+```
+
 That's it! Simply Sexy!
 
 ## Minimum Requirements
@@ -67,6 +78,7 @@ That's it! Simply Sexy!
 * Without bundler: `sudo gem install paloma`.
 * With bundler, add this to your Gemfile: `gem 'paloma'`
 * Require `paloma` in your `application.js`: `//= require paloma`
+* Insert the paloma hook in your view (in the layout is recommended so it's included everywhere): `insert_paloma_hook`
 
 
 ## Controllers
@@ -308,14 +320,9 @@ $(document).on('page:load', function(){
 
 ## Gotchas
 
-* Paloma  will execute on all `render` calls, except for calls with the following formats: `js`, `json`, `xml`, and `file`.
-
-   Example:
-   
-   ```ruby
-   render :json => {:x => 1}  # Paloma will not execute`
-   render :partial => '/path/to/partial'  # Paloma will execute
-   ```
+* Paloma  will only execute if its hook is included in the view. If your
+  page-specific code doesn't run, make sure the return value of
+  `insert_paloma_hook` is added to the page: `<%= insert_paloma_hook %>`
 
 * It will cause conflicts if you have a controller and a module that has the same name.
 

--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -115,16 +115,11 @@ module Paloma
       #
       def insert_paloma_hook
         if self.paloma.has_request?
+          hook = view_context.render(
+            :partial => 'paloma/hook',
+            :locals => {:request => self.paloma.request})
           self.paloma.clear_request
-
-          # Render the partial if it is present, otherwise do nothing. 
-          begin
-            view_context.render(
-              :partial => 'paloma/hook',
-              :locals => {:request => self.paloma.request})
-          rescue ActionView::MissingTemplate
-            # NOOP
-          end
+          hook
         end
       end
     end

--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -12,7 +12,7 @@ module Paloma
         prepend_view_path "#{Paloma.root}/app/views/"
 
         before_filter :track_paloma_request
-        after_filter :append_paloma_hook, :if => :not_redirect?
+        helper_method :insert_paloma_hook
       end
     end
 
@@ -107,59 +107,26 @@ module Paloma
 
 
       #
-      # Before rendering html reponses,
-      # this is exectued to append Paloma's html hook to the response.
+      # Call in your view layout to insert Paloma's html hook
+      # into the response.
       #
       # The html hook contains the javascript code that
       # will execute the tracked Paloma requests.
       #
-      def append_paloma_hook
-        return true if self.paloma.has_no_request?
-       
-        # Render the partial if it is present, otherwise do nothing. 
-        begin
-          hook = view_context.render(
-                   :partial => 'paloma/hook',
-                   :locals => {:request => self.paloma.request})
-        rescue ActionView::MissingTemplate
-          return true
-        end
-
-        before_body_end_index = response_body[0].rindex('</body>')
-
-        # Append the hook after the body tag if it is present.
-        if before_body_end_index.present?
-          before_body = response_body[0][0, before_body_end_index].html_safe
-          after_body = response_body[0][before_body_end_index..-1].html_safe
-
-          response.body = before_body + hook + after_body
-        else
-          # If body tag is not present, append hook in the response body
-          response.body += hook
-        end
-
-        self.paloma.clear_request
-      end
-    end
-
-
-    def not_redirect?
-      self.status != 302
-    end
-
-
-    #
-    # Make sure not to execute paloma on the following response type
-    #
-    def render options = nil, extra_options = {}, &block
-      [:json, :js, :xml, :file].each do |format|
-        if options.has_key?(format)
+      def insert_paloma_hook
+        if self.paloma.has_request?
           self.paloma.clear_request
-          break
-        end
-      end if options.is_a?(Hash)
 
-      super
+          # Render the partial if it is present, otherwise do nothing. 
+          begin
+            view_context.render(
+              :partial => 'paloma/hook',
+              :locals => {:request => self.paloma.request})
+          rescue ActionView::MissingTemplate
+            # NOOP
+          end
+        end
+      end
     end
 
 


### PR DESCRIPTION
Many of the issues with the gem are people saying that the hook is inserted in responses where it doesn't belong. For example, when generating text #59, generating JSON #37, sending a file #62, sending a live response #47, doing AJAX #31. I had an issue with the hook being inserted in generated Excel files.

I think this is because Paloma tries to automatically decide when to include the hook by looking at the response type and by hooking into the render call. It's obviously difficult to anticipate all the cases where this doesn't work, but the examples above show that the current solution gets it wrong for a lot of cases.

Wouldn't it be better to require gem users to explicitly include the Paloma hook where they want it in their views?

I renamed `append_paloma_hook` to `insert_paloma_hook`

This new helper should be called once in the views (in the layout is a good place), just before the closing body tag.

This gets rid of the most "magical" thing in the gem and avoids having to search the response body for the closing body tag to insert the hook. It solves any potential "mis-insertions" for unexpected responses. It fixes inserting the hook into the output of Rails engines that don't expect it.

The only big issue is that this is a breaking change since people that use the gem today would have to add one line to their layout.

Any thoughts? And once again, thanks for spending some time keeping up this cool gem :+1: 