### PR TITLE
Paloma sometimes renders when you are doing JS request

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -147,6 +147,8 @@ module Paloma
     # Make sure not to execute paloma on the following response type
     #
     def render options = nil, extra_options = {}, &block
+      rejected_formats = ["text/javascript", "application/xml", "application/json"]
+      self.paloma.clear_request if rejected_formats.include?(request.format)
       [:json, :js, :xml, :file].each do |format|
         if options.has_key?(format)
           self.paloma.clear_request


### PR DESCRIPTION
When rendering server side JS templates paloma can render unless you specify js in the render option.
However a lot of people tend to call JS templates like this (especially in older apps).
```ruby
respond_to do |format|
  format.js do
    @job.reload # to refresh total
     render :layout => false
  end
end
````
So you make a remote response on a form to the #create action and create.js.erb would be called. This will return with Paloma rendered at the bottom.  Which breaks the response. 