### PR TITLE
Remove jQuery Dependency

### DIFF
--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -17,15 +17,8 @@
         params: request.params
       });
 
-      // Remove old hooks
-      var hooks = document.getElementsByClassName('js-paloma-hook');
-
-      for (var i = 0, n = hooks.length; i < n; i++){
-        var hook = hooks[i],
-            palomaid = hook.dataset.palomaid.toString();
-
-        if (palomaid != id) hook.parentNode.removeChild(hook);
-      }
+      var self  = document.querySelector("[data-palomaid='" + id + "']");
+      if (self) self.parentNode.removeChild(self);
 
     })();
   </script>

--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -3,26 +3,30 @@
 <div class="js-paloma-hook" data-palomaid="<%= id %>">
   <script type="text/javascript">
     (function(){
-      // Do not continue if Paloma not found.
-      if (window['Paloma'] === undefined) {
-        return true;
-      }
 
+      if (window['Paloma'] === undefined) return true;
       Paloma.env = '<%= Rails.env %>';
 
-      // Remove any callback details if any
-      var hook =
-        document.querySelector("[data-palomaid='" + <%= id %> + "']")[0];
-
-      if (hook) hook.parentNode.removeChild(hook);
-
-      var request = <%= request.to_json.html_safe %>;
+      var id = "<%= id %>",
+          request = <%= request.to_json.html_safe %>;
 
       Paloma.engine.setRequest({
-        id: "<%= id %>",
-        resource: request['resource'],
-        action: request['action'],
-        params: request['params']});
+        id: id,
+        resource: request.resource,
+        action: request.action,
+        params: request.params
+      });
+
+      // Remove old hooks
+      var hooks = document.getElementsByClassName('js-paloma-hook');
+
+      for (var i = 0, n = hooks.length; i < n; i++){
+        var hook = hooks[i],
+            palomaid = hook.dataset.palomaid.toString();
+
+        if (palomaid != id) hook.parentNode.removeChild(hook);
+      }
+
     })();
   </script>
 </div>

--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -1,6 +1,6 @@
 <% id = "#{Time.now.to_i}#{(rand * 1000).ceil}" %>
 
-<div class="js-paloma-hook" data-id="<%= id %>">
+<div class="js-paloma-hook" data-palomaid="<%= id %>">
   <script type="text/javascript">
     (function(){
       // Do not continue if Paloma not found.
@@ -11,7 +11,10 @@
       Paloma.env = '<%= Rails.env %>';
 
       // Remove any callback details if any
-      $('.js-paloma-hook[data-id!=' + <%= id %> + ']').remove();
+      var hook =
+        document.querySelector("[data-palomaid='" + <%= id %> + "']")[0];
+
+      if (hook) hook.parentNode.removeChild(hook);
 
       var request = <%= request.to_json.html_safe %>;
 

--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -4,7 +4,7 @@
   <script type="text/javascript">
     (function(){
 
-      if (window['Paloma'] === undefined) return true;
+      if ( !window['Paloma'] ) return true;
       Paloma.env = '<%= Rails.env %>';
 
       var id = "<%= id %>",

--- a/paloma.gemspec
+++ b/paloma.gemspec
@@ -9,8 +9,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/kbparagua/paloma'
   s.license     = 'MIT'
 
-  s.add_dependency 'jquery-rails'
-
   s.add_development_dependency 'rails', ['~> 3.2.0']
   s.add_development_dependency 'rake', ['>= 0']
   s.add_development_dependency 'rspec', ['>= 0']

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'selenium-webdriver'
 gem 'jquery-turbolinks'
+gem 'test-unit'
 gemspec :path => '../'

--- a/test_app/app/assets/javascripts/application.js
+++ b/test_app/app/assets/javascripts/application.js
@@ -19,10 +19,7 @@
 
 
 // Uncomment if jquery.turbolinks is not used.
-// $(document).on('page:load', function(){
-//   Paloma.executeHook();
-//   Paloma.engine.start();
-// });
+// $(document).on('page:load', function(){ Paloma.start(); });
 
 
 //
@@ -57,15 +54,14 @@ NotFoos.prototype.otherAction = function(){};
 
 $(document).ready(function(){
 
-  Paloma.engine.start();
+  Paloma.start();
 
   $('#js-ajax-link').on('click', function(e){
     e.preventDefault();
 
     $.get($(this).prop('href'), function(response){
       $('#js-ajax-response').html(response);
-      Paloma.executeHook();
-      Paloma.engine.start();
+      Paloma.start();
     });
   });
 });

--- a/test_app/app/assets/javascripts/application.js
+++ b/test_app/app/assets/javascripts/application.js
@@ -56,6 +56,9 @@ NotFoos.prototype.otherAction = function(){};
 
 
 $(document).ready(function(){
+
+  Paloma.engine.start();
+
   $('#js-ajax-link').on('click', function(e){
     e.preventDefault();
 

--- a/test_app/app/assets/javascripts/application.js
+++ b/test_app/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery.turbolinks
 //= require jquery_ujs
-//=# require turbolinks
+//= require turbolinks
 //= require paloma
 //= require_tree .
 

--- a/test_app/spec/integration/basic_spec.rb
+++ b/test_app/spec/integration/basic_spec.rb
@@ -125,7 +125,7 @@ feature 'executing Paloma controller', :js => true do
   context 'controller#action at first then false' do
     it 'does not execute any js' do
       visit multiple_calls_4_main_index_path
-      expect(request).to be_nil
+      expect(paloma_executed?).to be_falsy
     end
   end
 
@@ -163,7 +163,7 @@ feature 'executing Paloma controller', :js => true do
     include_examples 'no paloma'
 
     it 'prevents execution of Paloma controller' do
-      expect(request).to be_nil
+      expect(paloma_executed?).to be_falsy
     end
   end
 

--- a/test_app/spec/spec_helper.rb
+++ b/test_app/spec/spec_helper.rb
@@ -33,5 +33,9 @@ end
 
 
 def request
-  page.evaluate_script 'Paloma.engine.getRequest()'
+  page.evaluate_script 'Paloma.engine.lastRequest()'
+end
+
+def paloma_executed?
+  page.evaluate_script 'Paloma.isExecuted()'
 end

--- a/vendor/assets/javascripts/paloma/controller_factory.js
+++ b/vendor/assets/javascripts/paloma/controller_factory.js
@@ -40,9 +40,6 @@
   var createConstructor = function(){
     var constructor = function(params){ this.params = params; }
 
-    $.extend(constructor, Paloma.Controller);
-    $.extend(constructor.prototype, Paloma.Controller.prototype);
-
     return constructor;
   };
 

--- a/vendor/assets/javascripts/paloma/init.js
+++ b/vendor/assets/javascripts/paloma/init.js
@@ -18,14 +18,9 @@ else {
   };
 }
 
-$(document).ready(function(){
-  // Do not continue if Paloma not found.
-  if (window['Paloma'] === undefined) {
-    if (window['console'] !== undefined) {
-      console.warn("Paloma not found. Require it in your application.js.");
-    }
-    return true;
-  }
 
-  Paloma.engine.start();
-});
+if ( !window['Paloma'] ){
+  if (window['console'] !== undefined){
+    console.warn("Paloma not found. Require it in your application.js.");
+  }
+}

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -16,14 +16,14 @@
 
   Paloma.engine = new Paloma.Engine({factory: Paloma._controllerFactory});
 
-
   Paloma.executeHook = function(){
-    var $hook = $('.js-paloma-hook:first script:first');
+    var hook = document.getElementsByClassName('js-paloma-hook')[0];
+    if (!hook) return;
 
-    if ($hook.length == 0){ return; }
+    var script = hook.getElementsByTagName('script')[0];
+    if (!script) return;
 
-    var hook = $hook.html();
-    eval(hook);
+    eval(script.innerHTML);
   };
 
 

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -16,7 +16,7 @@
 
   Paloma.engine = new Paloma.Engine({factory: Paloma._controllerFactory});
 
-  Paloma.executeHook = function(){
+  Paloma._executeHook = function(){
     var hook = document.getElementsByClassName('js-paloma-hook')[0];
     if (!hook) return;
 
@@ -25,6 +25,16 @@
 
     eval(script.innerHTML);
   };
+
+  Paloma.start = function(){
+    if ( !this.engine.hasRequest() ) this._executeHook();
+    if ( this.engine.hasRequest() ) this.engine.start();
+  };
+
+  Paloma.isExecuted = function(){
+    return this.engine.lastRequest().executed;
+  };
+
 
 
 })(window.Paloma);


### PR DESCRIPTION
- Remove jQuery statements from Paloma js files.
- Paloma `_hook` will auto-remove itself after its execution.
- `Paloma.start()` will replace `Paloma.engine.start()` and `Paloma.executeHook()`
- Paloma will not start by default, user will have the freedom to start Paloma anywhere by using `Paloma.start()` (most of the time inside `document.ready`)
- `Paloma.engine`'s request will be cleared after execution.