### PR TITLE
Refactor

### DIFF
--- a/test_app/spec/javascripts/controller_factory_spec.js
+++ b/test_app/spec/javascripts/controller_factory_spec.js
@@ -1,7 +1,7 @@
 
 describe('Paloma.ControllerFactory', function(){
 
-  var router = new Paloma.Router({namespace: '/', action: '#'});
+  var router = new Paloma.Router({namespaceDelimiter: '/'});
 
 
   describe('#make(name)', function(){

--- a/test_app/spec/javascripts/router_spec.js
+++ b/test_app/spec/javascripts/router_spec.js
@@ -1,7 +1,7 @@
 
 describe('Paloma.Router', function(){
   var delimiter = '/',
-      router = new Paloma.Router(delimiter);
+      router = new Paloma.Router({namespaceDelimiter: delimiter});
 
   describe('#parse(path)', function(){
 

--- a/vendor/assets/javascripts/paloma/controller.js
+++ b/vendor/assets/javascripts/paloma/controller.js
@@ -1,10 +1,3 @@
-(function(Paloma){
-
-  var Controller = function(params){
-    this.params = params;
-  };
-
-
-  Paloma.Controller = Controller;
-
-})(window.Paloma);
+Paloma.Controller = function(params){
+  this.params = params;
+};

--- a/vendor/assets/javascripts/paloma/controller_factory.js
+++ b/vendor/assets/javascripts/paloma/controller_factory.js
@@ -1,13 +1,11 @@
-(function(Paloma){
+Paloma.ControllerFactory = function(router){
+  this.instances = {};
+  this.router = router;
+};
 
+Paloma.ControllerFactory.prototype = {
 
-  var ControllerFactory = function(router){
-    this.instances = {};
-    this.router = router;
-  };
-
-
-  ControllerFactory.prototype.make = function(name){
+  make: function(name){
     var config = this.router.parse(name),
         scope = this.instances;
 
@@ -18,11 +16,10 @@
       scope = scope[namespace];
     }
 
-    return scope[config['controller']] = createConstructor();
-  };
+    return scope[config['controller']] = this._createConstructor();
+  },
 
-
-  ControllerFactory.prototype.get = function(name){
+  get: function(name){
     var config = this.router.parse(name),
         scope = this.instances;
 
@@ -34,19 +31,14 @@
     }
 
     return scope;
-  };
+  },
 
+  _createConstructor: function(){
+    var constructor = function(params){ Paloma.Controller.call(this, params); };
 
-  var createConstructor = function(){
-    var constructor = function(params){ this.params = params; }
+    constructor.prototype.__proto__ = Paloma.Controller.prototype;
 
     return constructor;
-  };
+  }
 
-
-
-
-
-  Paloma.ControllerFactory = ControllerFactory;
-
-})(window.Paloma);
+};

--- a/vendor/assets/javascripts/paloma/init.js
+++ b/vendor/assets/javascripts/paloma/init.js
@@ -20,7 +20,7 @@ else {
 
 
 if ( !window['Paloma'] ){
-  if (window['console'] !== undefined){
+  if ( !window['console'] ){
     console.warn("Paloma not found. Require it in your application.js.");
   }
 }

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -1,6 +1,6 @@
 (function(Paloma){
 
-  Paloma._router = new Paloma.Router('/');
+  Paloma._router = new Paloma.Router({namespaceDelimiter: '/'});
   Paloma._controllerFactory = new Paloma.ControllerFactory(Paloma._router);
 
   //

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -30,6 +30,4 @@
     return this.engine.lastRequest().executed;
   };
 
-
-
 })(window.Paloma);

--- a/vendor/assets/javascripts/paloma/router.js
+++ b/vendor/assets/javascripts/paloma/router.js
@@ -1,23 +1,27 @@
-(function(Paloma){
+Paloma.Router = function(options){
+  options = options || {};
+  this.namespaceDelimiter = options.namespaceDelimiter;
 
-  var Router = function(namespaceDelimiter){
-    this.namespaceDelimiter = namespaceDelimiter;
-  };
+  if (!this.namespaceDelimiter)
+    throw "Paloma.Router: namespaceDelimiter option is required.";
+};
 
+Paloma.Router.prototype = {
 
-  Router.prototype.parse = function(path){
+  parse: function(path){
     var parts = path.split(this.namespaceDelimiter),
         controller = parts.pop(),
         namespaces = parts;
 
     var controllerPath = namespaces.concat([controller]);
 
-    return {controllerPath: controllerPath,
-            namespaces: namespaces,
-            controller: controller};
-  };
+    return {
+      controllerPath: controllerPath,
+      namespaces: namespaces,
+      controller: controller
+    };
+  }
+
+};
 
 
-  Paloma.Router = Router;
-
-})(window.Paloma);


### PR DESCRIPTION
- Refactor JS classes.
- Controllers will now inherit from `Paloma.Controller`.
- Change `Paloma.Router` argument from string to object (`options`).