### PR TITLE
Controller factory rework

### DIFF
--- a/test_app/spec/javascripts/controller_builder_spec.js
+++ b/test_app/spec/javascripts/controller_builder_spec.js
@@ -1,0 +1,49 @@
+describe('Paloma.ControllerBuilder', function(){
+
+  var TestController = Paloma.controller('Test');
+
+
+  describe('#build(options)', function(){
+
+    describe('when options.controller has no match', function(){
+      var factory = {get: function(controller){ return null; }},
+          builder = new Paloma.ControllerBuilder(factory);
+
+      it('returns null', function(){
+        var options = {controller: 'Test', action: 'show'};
+        expect( builder.build(options) ).toBeNull();
+      });
+    });
+
+    describe('when options.controller has a match', function(){
+      var factory = {get: function(controller){ return TestController; }},
+          builder = new Paloma.ControllerBuilder(factory);
+
+      var options = {
+        controller: 'Test',
+        action: 'show',
+        params: {a: 1, b: 2}
+      };
+
+      var controller = builder.build(options);
+
+      it('returns a new instance of the controller class', function(){
+        expect(controller instanceof TestController).toBeTruthy();
+      });
+
+      it("initializes controller instance's params", function(){
+        var expectedParams = {_controller: 'Test', _action: 'show', a: 1, b: 2};
+        var correct = true;
+
+        for (var k in expectedParams){
+          if (controller.params[k] != expectedParams[k])
+            correct = false;
+        }
+
+        expect(correct).toBeTruthy();
+      });
+    });
+
+  });
+
+});

--- a/test_app/spec/javascripts/controller_class_factory_spec.js
+++ b/test_app/spec/javascripts/controller_class_factory_spec.js
@@ -1,19 +1,19 @@
-describe('Paloma.ControllerBuilder', function(){
+describe('Paloma.ControllerClassFactory', function(){
 
-  var _builder = null;
-  function builder(){ return _builder; }
+  var _factory = null;
+  function factory(){ return _factory; }
 
-  function newBuilder(){
-    _builder = new Paloma.ControllerBuilder();
-    return _builder;
+  function newFactory(){
+    _factory = new Paloma.ControllerClassFactory();
+    return _factory;
   }
 
 
 
-  describe('#build(controllerAndParent, prototype)', function(){
+  describe('#make(controllerAndParent, prototype)', function(){
     describe('when controller is not yet existing', function(){
       it('creates a new controller', function(){
-        var controller = newBuilder().build('MyController'),
+        var controller = newFactory().make('MyController'),
             instance = new controller();
 
         expect(instance instanceof Paloma.BaseController).toBeTruthy();
@@ -21,7 +21,7 @@ describe('Paloma.ControllerBuilder', function(){
 
       describe('when prototype is present', function(){
         it('adds the prototype to the controller', function(){
-          var controller = newBuilder().build('MyController', {a: 100});
+          var controller = newFactory().make('MyController', {a: 100});
 
           expect(controller.prototype.a).toEqual(100);
         });
@@ -29,8 +29,8 @@ describe('Paloma.ControllerBuilder', function(){
 
       describe('when parent is present', function(){
         it('creates a subclass of that parent', function(){
-          var parent = newBuilder().build('Parent'),
-              child = builder().build('Child < Parent');
+          var parent = newFactory().make('Parent'),
+              child = factory().make('Child < Parent');
 
           var controller = new child();
           expect(controller instanceof parent).toBeTruthy();
@@ -40,13 +40,13 @@ describe('Paloma.ControllerBuilder', function(){
 
     describe('when controller is already existing', function(){
       it('returns the existing controller', function(){
-        var controller = newBuilder().build('test2');
-        expect( builder().build('test2') ).toEqual(controller);
+        var controller = newFactory().make('test2');
+        expect( factory().make('test2') ).toEqual(controller);
       });
 
       describe('when prototype is present', function(){
-        var controller = newBuilder().build('Test', {number: 9});
-        builder().build('Test', {number: 10});
+        var controller = newFactory().make('Test', {number: 9});
+        factory().make('Test', {number: 10});
 
         it('updates the current prototype', function(){
           expect(controller.prototype.number).toEqual(10);
@@ -54,12 +54,12 @@ describe('Paloma.ControllerBuilder', function(){
       });
 
       describe('when parent is present', function(){
-        var oldParent = newBuilder().build('OldParent'),
-            newParent = builder().build('NewParent');
+        var oldParent = newFactory().make('OldParent'),
+            newParent = factory().make('NewParent');
 
         describe('when no previous parent', function(){
-          var child = builder().build('ChildA');
-          builder().build('ChildA < NewParent');
+          var child = factory().make('ChildA');
+          factory().make('ChildA < NewParent');
 
           var instance = new child();
 
@@ -69,8 +69,8 @@ describe('Paloma.ControllerBuilder', function(){
         });
 
         describe('when has previous parent', function(){
-          var child = builder().build('ChildB < OldParent');
-          builder().build('ChildB < NewParent');
+          var child = factory().make('ChildB < OldParent');
+          factory().make('ChildB < NewParent');
 
           var instance = new child();
 
@@ -89,14 +89,14 @@ describe('Paloma.ControllerBuilder', function(){
   describe('#get(name)', function(){
     describe('when name has no match', function(){
       it('returns null', function(){
-        expect( newBuilder().get('unknown') ).toBeNull();
+        expect( newFactory().get('unknown') ).toBeNull();
       });
     });
 
     describe('when name has match', function(){
       it('returns the matched controller', function(){
-        var controller = newBuilder().build('myController');
-        expect( builder().get('myController') ).toEqual(controller);
+        var controller = newFactory().make('myController');
+        expect( factory().get('myController') ).toEqual(controller);
       });
     });
   });

--- a/vendor/assets/javascripts/paloma/controller_builder.js
+++ b/vendor/assets/javascripts/paloma/controller_builder.js
@@ -25,7 +25,7 @@ Paloma.ControllerBuilder.prototype = {
     };
 
     for (var k in this.options.params)
-      if (this.options.hasOwnProperty(k))
+      if (this.options.params.hasOwnProperty(k))
         params[k] = this.options.params[k];
 
     return params;

--- a/vendor/assets/javascripts/paloma/controller_builder.js
+++ b/vendor/assets/javascripts/paloma/controller_builder.js
@@ -1,0 +1,34 @@
+Paloma.ControllerBuilder = function(classFactory){
+  this.classFactory = classFactory;
+  this.options = {};
+};
+
+Paloma.ControllerBuilder.prototype = {
+
+  build: function(options){
+    this.options = options;
+
+    var ControllerClass = this._controllerClass(),
+    if ( !ControllerClass ) return null;
+
+    return new ControllerClass( this._buildParams() );
+  },
+
+  _controllerClass: function(){
+    return this.classFactory.get( this.options.controller );
+  },
+
+  _buildParams: function(){
+    var params = {
+      _controller: this.options.controller,
+      _action: this.options.action
+    };
+
+    for (var k in this.options.params)
+      if (this.options.hasOwnProperty(k))
+        params[k] = this.options.params[k];
+
+    return params;
+  }
+
+};

--- a/vendor/assets/javascripts/paloma/controller_builder.js
+++ b/vendor/assets/javascripts/paloma/controller_builder.js
@@ -8,7 +8,7 @@ Paloma.ControllerBuilder.prototype = {
   build: function(options){
     this.options = options;
 
-    var ControllerClass = this._controllerClass(),
+    var ControllerClass = this._controllerClass();
     if ( !ControllerClass ) return null;
 
     return new ControllerClass( this._buildParams() );

--- a/vendor/assets/javascripts/paloma/controller_class_factory.js
+++ b/vendor/assets/javascripts/paloma/controller_class_factory.js
@@ -1,11 +1,11 @@
-Paloma.ControllerBuilder = function(){
+Paloma.ControllerClassFactory = function(){
   this._controllers = {};
   this._inheritanceSymbol = '<';
 };
 
-Paloma.ControllerBuilder.prototype = {
+Paloma.ControllerClassFactory.prototype = {
 
-  build: function(controllerAndParent, prototype){
+  make: function(controllerAndParent, prototype){
     var parts = this._extractParts(controllerAndParent),
         controller = this._getOrCreate( parts.controller );
 

--- a/vendor/assets/javascripts/paloma/engine.js
+++ b/vendor/assets/javascripts/paloma/engine.js
@@ -37,13 +37,11 @@ Paloma.Engine.prototype = {
     var controller = this._buildController();
     if (!controller) return;
 
-    var action = controller[ this._request.action ];
-    if (!action) return;
-
     var callbackPerformer = new Paloma.BeforeCallbackPerformer(controller);
     callbackPerformer.perform( this._request.action );
 
-    action.call(controller);
+    var method = controller[ this._request.action ];
+    if (method) method.call(controller);
 
     this._lastRequest.executed = true;
   },

--- a/vendor/assets/javascripts/paloma/index.js
+++ b/vendor/assets/javascripts/paloma/index.js
@@ -2,5 +2,6 @@
 //= require ./base_controller.js
 //= require ./controller_class_factory.js
 //= require ./before_callback_performer.js
+//= require ./controller_builder.js
 //= require ./engine.js
 //= require ./paloma.js

--- a/vendor/assets/javascripts/paloma/index.js
+++ b/vendor/assets/javascripts/paloma/index.js
@@ -1,6 +1,6 @@
 //= require ./init.js
 //= require ./base_controller.js
-//= require ./controller_builder.js
+//= require ./controller_class_factory.js
 //= require ./before_callback_performer.js
 //= require ./engine.js
 //= require ./paloma.js

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -1,10 +1,15 @@
 (function(Paloma){
 
-  Paloma._controllerClassFactory = new Paloma.ControllerClassFactory();
-  Paloma.engine = new Paloma.Engine({builder: Paloma._controllerBuilder});
+  var classFactory = new Paloma.ControllerClassFactory(),
+      controllerBuilder = new Paloma.ControllerBuilder(classFactory),
+      engine = new Paloma.Engine(controllerBuilder)
+
+  Paloma._controllerClassFactory = classFactory;
+  Paloma._controllerBuilder = controllerBuilder
+  Paloma.engine = engine;
 
   Paloma.controller = function(name, prototype){
-    return Paloma._controllerClassFactory.make(name, prototype);
+    return classFactory.make(name, prototype);
   };
 
   Paloma._executeHook = function(){
@@ -13,12 +18,12 @@
   };
 
   Paloma.start = function(){
-    if ( !this.engine.hasRequest() ) this._executeHook();
-    if ( this.engine.hasRequest() ) this.engine.start();
+    if ( !engine.hasRequest() ) this._executeHook();
+    if ( engine.hasRequest() ) engine.start();
   };
 
   Paloma.isExecuted = function(){
-    return this.engine.lastRequest().executed;
+    return engine.lastRequest().executed;
   };
 
 })(window.Paloma);

--- a/vendor/assets/javascripts/paloma/paloma.js
+++ b/vendor/assets/javascripts/paloma/paloma.js
@@ -1,10 +1,10 @@
 (function(Paloma){
 
-  Paloma._controllerBuilder = new Paloma.ControllerBuilder();
+  Paloma._controllerClassFactory = new Paloma.ControllerClassFactory();
   Paloma.engine = new Paloma.Engine({builder: Paloma._controllerBuilder});
 
   Paloma.controller = function(name, prototype){
-    return Paloma._controllerBuilder.build(name, prototype);
+    return Paloma._controllerClassFactory.make(name, prototype);
   };
 
   Paloma._executeHook = function(){


### PR DESCRIPTION
- Rename `ControllerBuilder` to `ControllerClassFactory`.
- Create new `ControllerBuilder` that builds controller instances.