### PR TITLE
before_filter is deprecated and will be removed in Rails 5.1

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -11,7 +11,7 @@ module Paloma
       base.module_eval do
         prepend_view_path "#{Paloma.root}/app/views/"
 
-        before_filter :track_paloma_request
+        before_action :track_paloma_request
         helper_method :insert_paloma_hook
       end
     end
@@ -33,7 +33,7 @@ module Paloma
         scope[:only] = options[:only] if options[:only]
         scope[:except] = options[:except] if options[:except]
 
-        self.before_filter(
+        self.before_action(
           Proc.new {
             self.js path_or_options, options[:params]
           },


### PR DESCRIPTION
Replaced before_filter with before_action to avoid deprecation warning.